### PR TITLE
changing django.utils.six to six

### DIFF
--- a/escapejson/templatetags/escapejson.py
+++ b/escapejson/templatetags/escapejson.py
@@ -1,8 +1,8 @@
 import json
+import six
 
 from django import template
 from django.core.serializers.json import DjangoJSONEncoder
-from django.utils import six
 from django.utils.safestring import mark_safe
 from ..escapejson import escapejson
 


### PR DESCRIPTION
Following django 3.0 compatibility, changing from django's version of six to the official version of six.
https://pypi.org/project/six/

Not sure how or where to update pip requirements to include `pip install six`.